### PR TITLE
tweak(builder): node selection improvements

### DIFF
--- a/src/app/builder/components/InteractiveFlowchart.tsx
+++ b/src/app/builder/components/InteractiveFlowchart.tsx
@@ -185,60 +185,46 @@ const InteractiveFlowchart: React.FC = () => {
     const node = graphData.nodes.find((n) => n.id === nodeId);
     if (!node) return;
 
+    // Check if node is already selected
+    if (selectedNodes.includes(nodeId)) {
+      const index = selectedNodes.indexOf(nodeId);
+      setSelectedNodes((prev) => prev.slice(0, index));
+      return;
+    }
+
+    // First selection must be from column 0
     if (selectedNodes.length === 0) {
-      // Must pick from column 0 first
       if (node.column !== 0) return;
       setSelectedNodes([nodeId]);
       return;
     }
 
+    // Check if this is a valid next selection
     const lastSelectedId = selectedNodes[selectedNodes.length - 1];
-    const lastSelectedNode = graphData.nodes.find((n) => n.id === lastSelectedId);
-    if (!lastSelectedNode) return;
-
-    // gather edges from lastSelectedId that pass condition
-    const validNextEdges = graphData.edges.filter((edge) => {
-      if (edge.from !== lastSelectedId) return false;
-      if (edge.condition && !edge.condition(selectedNodes)) return false;
-      return true;
-    });
+    const validNextEdges = graphData.edges.filter(
+      (edge) => edge.from === lastSelectedId && (!edge.condition || edge.condition(selectedNodes))
+    );
     const validNextIds = validNextEdges.map((e) => e.to);
 
-    // forward or backward?
-    const goingForward = validNextIds.includes(nodeId);
-    const goingBack = node.column < lastSelectedNode.column;
+    if (!validNextIds.includes(nodeId)) return;
 
-    if (!goingForward && !goingBack) return;
-
-    // if going back
-    if (goingBack) {
-      if (!selectedNodes.includes(nodeId)) return;
-      const index = selectedNodes.indexOf(nodeId);
-      setSelectedNodes((prev) => prev.slice(0, index + 1));
-      return;
-    }
-
-    // going forward
+    // Add new selection
     const currentColumn = node.column;
-    if (currentColumn < selectedNodes.length) {
-      // slice off future picks
-      setSelectedNodes((prev) => prev.slice(0, currentColumn));
-    }
-
     setSelectedNodes((prev) => {
       const newSel = [...prev];
       newSel[currentColumn] = nodeId;
-      return newSel;
+      return newSel.slice(0, currentColumn + 1);
     });
   };
 
-  // Reset / Back
+  // Reset handler - simply clears all selections
   const handleReset = () => setSelectedNodes([]);
-  const handleBack = () => {
-    if (selectedNodes.length > 0) {
-      setSelectedNodes((prev) => prev.slice(0, prev.length - 1));
-    }
-  };
+
+  // Back handler - removes the last selected node
+  const handleBack = () => setSelectedNodes((prev) => prev.slice(0, -1));
+
+  // Can go back - determines if back button should be enabled
+  const canGoBack = selectedNodes.length > 0;
 
   // Render edges
   const renderEdges = () => {

--- a/src/app/builder/components/MobileInteractiveFlowchart.tsx
+++ b/src/app/builder/components/MobileInteractiveFlowchart.tsx
@@ -183,35 +183,30 @@ const MobileInteractiveFlowchart: React.FC = () => {
     const node = graphData.nodes.find((n) => n.id === nodeId);
     if (!node) return;
 
+    // Check if node is already selected
+    if (selectedNodes.includes(nodeId)) {
+      const index = selectedNodes.indexOf(nodeId);
+      setSelectedNodes((prev) => prev.slice(0, index));
+      return;
+    }
+
+    // First selection must be from column 0
     if (selectedNodes.length === 0) {
       if (node.column !== 0) return;
       setSelectedNodes([nodeId]);
       return;
     }
 
+    // Check if this is a valid next selection
     const lastSelectedId = selectedNodes[selectedNodes.length - 1];
-    const lastSelectedNode = graphData.nodes.find((n) => n.id === lastSelectedId);
-    if (!lastSelectedNode) return;
-
-    const validNextEdges = graphData.edges.filter((edge) => {
-      if (edge.from !== lastSelectedId) return false;
-      if (edge.condition && !edge.condition(selectedNodes)) return false;
-      return true;
-    });
+    const validNextEdges = graphData.edges.filter(
+      (edge) => edge.from === lastSelectedId && (!edge.condition || edge.condition(selectedNodes))
+    );
     const validNextIds = validNextEdges.map((e) => e.to);
 
-    const goingForward = validNextIds.includes(nodeId);
-    const goingBack = node.column < lastSelectedNode.column;
+    if (!validNextIds.includes(nodeId)) return;
 
-    if (!goingForward && !goingBack) return;
-
-    if (goingBack) {
-      if (!selectedNodes.includes(nodeId)) return;
-      const index = selectedNodes.indexOf(nodeId);
-      setSelectedNodes((prev) => prev.slice(0, index + 1));
-      return;
-    }
-
+    // Add new selection
     const currentColumn = node.column;
     setSelectedNodes((prev) => {
       const newSel = [...prev];

--- a/src/app/builder/components/MobileInteractiveFlowchart.tsx
+++ b/src/app/builder/components/MobileInteractiveFlowchart.tsx
@@ -1,3 +1,5 @@
+// src/app/builder/components/MobileInteractiveFlowchart.tsx
+
 import React, { useState, useRef, useLayoutEffect } from 'react';
 import { ToastContainer, toast } from 'react-toastify';
 import { Info } from 'lucide-react';

--- a/src/app/hooks/useLongPress.tsx
+++ b/src/app/hooks/useLongPress.tsx
@@ -1,3 +1,5 @@
+// src/app/hooks/useLongPress.tsx
+
 import { useCallback, useRef } from 'react';
 
 interface UseLongPressProps {
@@ -10,20 +12,35 @@ export const useLongPress = ({ onLongPress, onClick, ms = 500 }: UseLongPressPro
   const timerRef = useRef<NodeJS.Timeout>();
   const isLongPress = useRef(false);
 
-  const start = useCallback(() => {
-    isLongPress.current = false;
-    timerRef.current = setTimeout(() => {
-      isLongPress.current = true;
-      onLongPress();
-    }, ms);
-  }, [onLongPress, ms]);
+  const start = useCallback(
+    (e: React.TouchEvent | React.MouseEvent) => {
+      // If it's a touch event, prevent mouse events from firing
+      if ('touches' in e) {
+        e.preventDefault();
+      }
+
+      isLongPress.current = false;
+
+      timerRef.current = setTimeout(() => {
+        isLongPress.current = true;
+        onLongPress();
+      }, ms);
+    },
+    [onLongPress, ms]
+  );
 
   const stop = useCallback(
-    (e: { preventDefault: () => void }) => {
-      e.preventDefault();
+    (e: React.TouchEvent | React.MouseEvent) => {
+      // For touch events, need to prevent default to avoid ghost clicks
+      if ('touches' in e || 'changedTouches' in e) {
+        e.preventDefault();
+      }
+
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
+
+      // If it wasn't a long press, trigger click
       if (!isLongPress.current && onClick) {
         onClick();
       }
@@ -31,11 +48,24 @@ export const useLongPress = ({ onLongPress, onClick, ms = 500 }: UseLongPressPro
     [onClick]
   );
 
+  const cancel = useCallback((e?: React.TouchEvent | React.MouseEvent) => {
+    if (e && ('touches' in e || 'changedTouches' in e)) {
+      e.preventDefault();
+    }
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+  }, []);
+
   return {
-    onMouseDown: start,
     onTouchStart: start,
-    onMouseUp: stop,
-    onMouseLeave: stop,
     onTouchEnd: stop,
+    onTouchCancel: cancel,
+    onMouseDown: start,
+    onMouseUp: stop,
+    onMouseLeave: cancel,
+    // Prevent long-press context menu on mobile
+    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
   };
 };


### PR DESCRIPTION
- Improved 'back' behavior. Now unselects the previously selected node
- Can click an already selected node to unselect it
- Unclicking a selected node causes an unselection cascade, essentially resetting the flowchart to where you clicked
- Fixed an issue whereby touch / click / hover events were being conflated in portrait view (without touch controls) and causing selections on hover